### PR TITLE
avoid global after and before :all blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2
+ - Avoid rspec.configure global after and before :all blocks
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/logstash-output-statsd.gemspec
+++ b/logstash-output-statsd.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-statsd'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send metrics to StatsD"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/statsd_spec.rb
+++ b/spec/outputs/statsd_spec.rb
@@ -7,6 +7,14 @@ describe LogStash::Outputs::Statsd do
   let(:host)   { "localhost" }
   let(:port)   { @server.port }
 
+  before(:all) do
+    @server = StatsdServer.new.run(random_port)
+  end
+
+  after(:all) do
+    @server.close
+  end
+
   describe "registration and close" do
 
     it "should register without errors" do

--- a/spec/outputs/statsd_spec.rb
+++ b/spec/outputs/statsd_spec.rb
@@ -5,14 +5,11 @@ require_relative "../spec_helper"
 describe LogStash::Outputs::Statsd do
 
   let(:host)   { "localhost" }
-  let(:port)   { @server.port }
+  let(:port)   { rand(2000..10000) }
+  let!(:server) { StatsdServer.new.run(port) }
 
-  before(:all) do
-    @server = StatsdServer.new.run(random_port)
-  end
-
-  after(:all) do
-    @server.close
+  after(:each) do
+    server.close
   end
 
   describe "registration and close" do
@@ -46,7 +43,7 @@ describe LogStash::Outputs::Statsd do
 
       it "should receive data send to the server" do
         subject.receive(event)
-        expect(@server.received).to include("logstash.spec.foo.bar:0.1|c")
+        expect(server.received).to include("logstash.spec.foo.bar:0.1|c")
       end
 
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,15 +55,6 @@ module StatdHelpers
 end
 
 RSpec.configure do |c|
-
   c.include StatdHelpers
-
-  c.before(:all) do
-    srand(c.seed)
-    @server = StatsdServer.new.run(random_port)
-  end
-
-  c.after(:all) do
-    @server.close
-  end
+  srand(c.seed)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,15 +46,6 @@ class StatsdServer
 
 end
 
-module StatdHelpers
-
-  def random_port
-    rand(2000..10000)
-  end
-
-end
-
 RSpec.configure do |c|
-  c.include StatdHelpers
   srand(c.seed)
 end


### PR DESCRIPTION
this plugin's specs use the global RSpec.configure to set up an after and before :all block.
when running the specs with other plugins there might be a conflict so this PR moves the blocks to the plugin spec (instead of global)