### PR TITLE
Fix randomly failling test

### DIFF
--- a/spec/outputs/statsd_spec.rb
+++ b/spec/outputs/statsd_spec.rb
@@ -43,7 +43,12 @@ describe LogStash::Outputs::Statsd do
 
       it "should receive data send to the server" do
         subject.receive(event)
-        expect(server.received).to include("logstash.spec.foo.bar:0.1|c")
+        # Since we are dealing with threads and networks, 
+        # we might experience delays or timing issues.
+        # lets try a few times before giving up completely.
+        try {
+          expect(server.received).to include("logstash.spec.foo.bar:0.1|c")
+        }
       end
 
     end


### PR DESCRIPTION
Since the mock server is creating threads and reading from IO its
fair to try a few time the asserts before giving up completely.

Fixes #14